### PR TITLE
Fix/return option for sign in component in profile

### DIFF
--- a/portato/src/Components/AuthWrapper.tsx
+++ b/portato/src/Components/AuthWrapper.tsx
@@ -1,8 +1,10 @@
 import React from "react";
-import { Spin } from "antd";
+import { Button, Spin } from "antd";
 import { auth } from "../firebaseConfig";
 import { onAuthStateChanged, User } from "firebase/auth";
 import FirebaseAuth from "../Components/FirebaseAuth";
+import BackButton from "./Buttons/BackButton";
+import PageLayout from "../Pages/Layouts/PageLayoutTest";
 
 interface AuthWrapperProps {
   Component: React.FC;
@@ -40,7 +42,17 @@ const AuthWrapper: React.FC<AuthWrapperProps> = ({ Component }) => {
   }
 
   console.log("Rendering user:", user); // Added console log
-  return user ? <Component /> : <FirebaseAuth />;
+  return user ? (
+    <Component />
+  ) : (
+    <PageLayout>
+      {" "}
+      <div style={{ position: "absolute", top: "40%", left: "20%" }}>
+        {" "}
+        <FirebaseAuth />
+      </div>
+    </PageLayout>
+  );
 };
 
 export default AuthWrapper;

--- a/portato/src/Components/AuthWrapper.tsx
+++ b/portato/src/Components/AuthWrapper.tsx
@@ -5,6 +5,7 @@ import { onAuthStateChanged, User } from "firebase/auth";
 import FirebaseAuth from "../Components/FirebaseAuth";
 import BackButton from "./Buttons/BackButton";
 import PageLayout from "../Pages/Layouts/PageLayoutTest";
+import "./PortatoStyleSheet.css";
 
 interface AuthWrapperProps {
   Component: React.FC;
@@ -46,9 +47,7 @@ const AuthWrapper: React.FC<AuthWrapperProps> = ({ Component }) => {
     <Component />
   ) : (
     <PageLayout>
-      {" "}
-      <div style={{ position: "absolute", top: "40%", left: "20%" }}>
-        {" "}
+      <div className="centered-container">
         <FirebaseAuth />
       </div>
     </PageLayout>

--- a/portato/src/Components/PortatoStyleSheet.css
+++ b/portato/src/Components/PortatoStyleSheet.css
@@ -1,0 +1,8 @@
+.centered-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+  }


### PR DESCRIPTION
**Related to:** Prs: # , Github issues: # :

*You can use Fixes # . to auto close an issue with this PR.*
Fixes #34 

- Adds css component to center container
- applies it to AuthWrapper

<h2>Changes proposed in this pull request:</h2>
Wrapped the authenticator in page layout and some styling.

<h2>Screenshots / Screencasts / GIFs:</h2>

![Screenshot from 2023-04-25 22-23-24](https://user-images.githubusercontent.com/58119670/234395241-8829b1d7-dad4-43d9-a075-27e84be0ce3f.png)
