### PR TITLE
Display the image in summary

### DIFF
--- a/portato/src/Pages/Sender/Summary.tsx
+++ b/portato/src/Pages/Sender/Summary.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import PageLayout from "../Layouts/PageLayoutTest";
-import { Typography, Card, Modal } from "antd";
+import { Typography, Card, Modal, Image } from "antd";
 import ProgressBar from "../../Components/ProgressBar";
 import ConfirmButton from "../../Components/Buttons/ConfirmButton";
 import BackButton from "../../Components/Buttons/BackButton";
@@ -68,6 +68,7 @@ const Summary: React.FC = () => {
       console.log("No user is signed in.");
     }
   };
+  const [visible, setVisible] = useState(false);
 
   return (
     <PageLayout>
@@ -116,7 +117,24 @@ const Summary: React.FC = () => {
         </div>
         <div>
           <Title level={4}> Images</Title>
-          <Typography> {objecInfo.images} </Typography>
+          <Image
+            preview={{ visible: false }}
+            height={100}
+            width={100}
+            src={objecInfo.images[0]}
+            onClick={() => setVisible(true)}
+          >
+            {" "}
+          </Image>
+          <div style={{ display: "none" }}>
+            <Image.PreviewGroup
+              preview={{ visible, onVisibleChange: (vis) => setVisible(vis) }}
+            >
+              {objecInfo.images.map((image) => (
+                <Image src={image} />
+              ))}
+            </Image.PreviewGroup>
+          </div>
         </div>
       </Card>
       {user ? (


### PR DESCRIPTION

Fixes #44 
<h2>Changes proposed in this pull request:</h2>

Image previewer for image array, displays the first image. When clicked, you can naviagte through the other images

![Screenshot from 2023-05-01 18-57-13](https://user-images.githubusercontent.com/58119670/235492490-d36a5d85-f180-4523-828e-acee26085bfc.png)
![Screenshot from 2023-05-01 18-57-20](https://user-images.githubusercontent.com/58119670/235492494-dd08cee7-f5f1-4dbc-920f-f3a2370827ce.png)
![Screenshot from 2023-05-01 18-57-25](https://user-images.githubusercontent.com/58119670/235492497-6672cbda-21cd-4702-a394-8b277ca53fa9.png)
