### PR TITLE
Updates target email adress to send to support@portato.io

### DIFF
--- a/functions/src/emailSender.js
+++ b/functions/src/emailSender.js
@@ -25,7 +25,7 @@ function sendEmail(req, res) {
 
       const mailOptions = {
         from: 'hugo@portato.io',
-        to: 'mehdi@portato.io',
+        to: 'support@portato.io',
         subject: 'New Message from React Web App',
         text: `${name} (${email}) says: ${message}`,
       };


### PR DESCRIPTION
Partly fixes #65 
As the sending is done from my email, gmail filters the notifications and i don't get the support email notifications