### PR TITLE
Feature/deal routes screen

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,6 @@
   "extends": ["react-app", "plugin:prettier/recommended"],
   "plugins": ["prettier"],
   "rules": {
-    "prettier/prettier": "error"
+    "prettier/prettier": "error" //TMP Meĥdi
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-  "git-blame.gitWebUrl": ""
+  "git-blame.gitWebUrl": "",
+  "editor.defaultFormatter": "rvest.vs-code-prettier-eslint",
+  "editor.formatOnPaste": false, // required
+  "editor.formatOnType": false, // required
+  "editor.formatOnSave": true, // optional
+  "editor.formatOnSaveMode": "file", // required to format on save
+  "files.autoSave": "onFocusChange", // optional but recommended
+  "vs-code-prettier-eslint.prettierLast": "false" // set as "true" to run 'prettier' last not first
 }

--- a/src/Components/DealsContents.tsx
+++ b/src/Components/DealsContents.tsx
@@ -1,0 +1,11 @@
+import Typography from 'antd/es/typography/Typography';
+
+function DealsContent() {
+  return (
+    <div style={{ height: '100vh' }}>
+      <Typography> Confirmed Deliverires </Typography>
+      <Typography> Delivery Suggestions(Coming) </Typography>
+    </div>
+  );
+}
+export default DealsContent;

--- a/src/Components/ProfileContent.tsx
+++ b/src/Components/ProfileContent.tsx
@@ -71,13 +71,13 @@ function ProfileContent() {
           >
             <div
               style={{
-                width: "min(50vw,50vh)",
-                height: "min(50vw,50vh)",
-                borderRadius: "50%",
-                backgroundColor: "#fff",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
+                width: 'min(50vw,50vh)',
+                height: 'min(50vw,50vh)',
+                borderRadius: '50%',
+                backgroundColor: '#fff',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
               }}
             >
               <UserOutlined style={{ fontSize: '48px' }} />

--- a/src/Components/RoutesContent.tsx
+++ b/src/Components/RoutesContent.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect, useState } from 'react';
+import PageLayout from '../Pages/Layouts/PageLayoutTest';
+import { List, Card, Button } from 'antd-mobile';
+import { UserOutlined } from '@ant-design/icons';
+import { useNavigate } from 'react-router-dom';
+
+function RoutesContent() {
+  const navigate = useNavigate();
+  const handleClick = () => {
+    navigate('/enterObjInfo');
+  };
+  return (
+    <div style={{ height: '100vh' }}>
+      <Button
+        size="large"
+        //style={{ display:'flex', left: '30%', top: '20%' }}
+        onClick={handleClick}
+      >
+        Create new Route
+      </Button>
+    </div>
+  );
+}
+export default RoutesContent;

--- a/src/Pages/Deliver.tsx
+++ b/src/Pages/Deliver.tsx
@@ -1,12 +1,27 @@
 import React from 'react';
 import PageLayout from './Layouts/PageLayoutTest';
-import { Typography } from 'antd';
-
-const { Title } = Typography;
+import { AutoCenter, Tabs } from 'antd-mobile';
+import RoutesContent from '../Components/RoutesContent';
+import DealsContent from '../Components/DealsContents';
 
 const Deliver: React.FC = () => {
   return (
     <PageLayout>
+      <Tabs style={{}}>
+        <Tabs.Tab title="Deals" key="deaks">
+          <AutoCenter>
+            <DealsContent />
+          </AutoCenter>
+        </Tabs.Tab>
+        <Tabs.Tab title="Routes" key="routes">
+          <AutoCenter>
+            <RoutesContent />
+          </AutoCenter>
+        </Tabs.Tab>
+      </Tabs>
+      {/* <Switch
+        onChange={toggleSwitch}
+      />
       <div
         style={{
           display: 'flex',
@@ -15,8 +30,9 @@ const Deliver: React.FC = () => {
           height: '100vh',
         }}
       >
-        <Title level={2}>Deliver</Title>
-      </div>
+         {isEnabled ? <Title>Deals</Title> : <Title>Routes</Title>}
+
+      </div> */}
     </PageLayout>
   );
 };

--- a/src/Pages/Profile.tsx
+++ b/src/Pages/Profile.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import 'firebaseui/dist/firebaseui.css';
 import AuthWrapper from '../Components/AuthWrapper';
 import ProfileContent from '../Components/ProfileContent';
 
 const Profile: React.FC = () => <AuthWrapper Component={ProfileContent} />;
-   
+
 export default Profile;

--- a/src/Pages/Sender/CreateSendRequest.tsx
+++ b/src/Pages/Sender/CreateSendRequest.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router-dom';
 import { Typography, Button } from 'antd';
 
 const { Title } = Typography;
-const progress = 25;
 
 const CreateSendRequest: React.FC = () => {
   const nextScreen = '/enterObjInfo';

--- a/src/Store/reducer.ts
+++ b/src/Store/reducer.ts
@@ -1,6 +1,5 @@
-import * as actionTypes from './actionTypes';
 import { AnyAction } from 'redux';
-import { IObjectInfo, ObjectInfoState } from '../type';
+import { IObjectInfo } from '../type';
 
 export function reducer(state: any, action: AnyAction): IObjectInfo {
   console.log(action.type);

--- a/src/type.ts
+++ b/src/type.ts
@@ -28,3 +28,17 @@ export type ObjectInfoAction = {
 };
 
 export type DispatchType = (args: ObjectInfoAction) => ObjectInfoAction;
+
+export interface IRouteInfo {
+  id: string;
+  departure_adress: string;
+  destination_adress: string;
+  acceptable_detour: number;
+  time: string;
+  delivery_capacity: string;
+}
+
+export type RouteInfoAction = {
+  type: string;
+  route: IRouteInfo;
+};


### PR DESCRIPTION

<h2>Changes proposed in this pull request:</h2>

Adds initial driver screen with two tabs to switch between deals and driver requests.
Starts adding object for driver request store

<h2>Screenshots / Screencasts / GIFs:</h2>

![image](https://user-images.githubusercontent.com/26309414/236681089-26b814c2-5344-48cc-b751-41886514b23a.png)
![image](https://user-images.githubusercontent.com/26309414/236681094-ecd28079-ab50-40ac-8a70-7fc2cda28fb5.png)


<h2>Performed test by PR author:</h2>

Tested OK.

