### PR TITLE
 code refactoring/cleaning/split in first screen in 2

### DIFF
--- a/src/Pages/Sender/CreateSendRequest.tsx
+++ b/src/Pages/Sender/CreateSendRequest.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { logEvent } from 'firebase/analytics';
 import { analytics } from '../../firebaseConfig';
 
-const NEXT_SCREEN = '/createSendRequest/enterObjInfo';
+const NEXT_SCREEN = '/createSendRequest/enter_request_name_desc';
 
 const CreateSendRequest: React.FC = () => {
   const { t } = useTranslation<string>(); // Setting the generic type to string

--- a/src/Pages/Sender/EnterRequestAddress.tsx
+++ b/src/Pages/Sender/EnterRequestAddress.tsx
@@ -1,36 +1,35 @@
-import React, { useState, useContext } from 'react';
+import React from 'react';
 import PageLayout from '../Layouts/PageLayoutTest';
 import NextButton from '../../Components/Buttons/NextButton';
 import BackButton from '../../Components/Buttons/BackButton';
 import ProgressBar from '../../Components/ProgressBar';
-import { Typography, Form, Input } from 'antd';
-import { SearchOutlined } from '@ant-design/icons';
+import { Form } from 'antd';
 import { IRequestInfo } from '../../type';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import AddressAutocomplete from '../../Components/AutoComplete';
 import { useTranslation } from 'react-i18next';
 import { logEvent } from 'firebase/analytics';
 import { analytics } from '../../firebaseConfig';
 
-const { Title } = Typography;
-const PROGRESS = 25;
-const NEXT_SCREEN = '/createSendRequest/enter_time';
+const PROGRESS = 40;
+const NEXT_SCREEN = '/createSendRequest/enter_request_time';
 
-const EnterAddress: React.FC = () => {
+const EnterRequestAddress: React.FC = () => {
   const objecInfo = useSelector(
     (state: { request: IRequestInfo }) => state.request
   );
-  console.log(objecInfo);
   const { t } = useTranslation<string>(); // Setting the generic type to string
   return (
     <PageLayout>
       <section className="section section-form mod-nomargin-top">
         <ProgressBar progress={PROGRESS} />
+
         <Form
           labelCol={{ span: 4 }}
           wrapperCol={{ span: 14 }}
           layout="horizontal"
         >
+          <h2>{t('requestAddresses.title')}</h2>
           <Form.Item className="input-wrapper">
             <label> {t('requestAddresses.pickupAddress')}</label>
             <AddressAutocomplete
@@ -40,13 +39,6 @@ const EnterAddress: React.FC = () => {
           </Form.Item>
 
           <Form.Item className="input-wrapper">
-            {/* <Input
-              name="delivery_adress"
-              value={adresses.delivery_adress}
-              onChange={handleInputChange}
-              prefix={<SearchOutlined />}
-              style={{ background: '', width: '90%' }}
-            /> */}
             <label> {t('requestAddresses.deliveryAddress')}</label>
             <AddressAutocomplete
               type={'delivery'}
@@ -72,4 +64,4 @@ const EnterAddress: React.FC = () => {
   );
 };
 
-export default EnterAddress;
+export default EnterRequestAddress;

--- a/src/Pages/Sender/EnterRequestNameDesc.tsx
+++ b/src/Pages/Sender/EnterRequestNameDesc.tsx
@@ -1,28 +1,24 @@
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 import PageLayout from '../Layouts/PageLayoutTest';
 import NextButton from '../../Components/Buttons/NextButton';
 import BackButton from '../../Components/Buttons/BackButton';
 import ProgressBar from '../../Components/ProgressBar';
-import UploadImage from '../../Components/UploadImage';
 
-import { Typography, Form, Input, Radio } from 'antd';
+import { Form, Input } from 'antd';
 import { useDispatch, useSelector } from 'react-redux';
-import { CAPACITY_OPTIONS } from '../../constant';
 import { setObject } from '../../Store/actions/requestActionCreators';
 import { IFirstObjectInfo, IRequestInfo } from '../../type';
 import { useTranslation } from 'react-i18next';
-import { Selector } from 'antd-mobile';
 
 import { logEvent } from 'firebase/analytics';
 import { analytics } from '../../firebaseConfig';
 
-const { Title } = Typography;
 const { TextArea } = Input;
 const PROGRESS = 0;
 
-const NEXT_SCREEN = '/createSendRequest/enter_address';
+const NEXT_SCREEN = '/createSendRequest/enter_request_size_weight_image';
 
-const EnterObjInfo: React.FC = () => {
+const EnterRequestNameDesc: React.FC = () => {
   const { t } = useTranslation<string>(); // Setting the generic type to string
 
   const objecInfo = useSelector(
@@ -48,12 +44,6 @@ const EnterObjInfo: React.FC = () => {
   };
 
   const dispatch = useDispatch();
-  const handleCapChange = (e: any) => {
-    setValues({
-      ...object,
-      size: e,
-    });
-  };
 
   const handleInputChange = (e: any) => {
     console.log(e);
@@ -104,33 +94,6 @@ const EnterObjInfo: React.FC = () => {
               placeholder={t('requestInfo.descriptionPlaceholder') || ''}
             />
           </Form.Item>
-
-          <Form.Item className="input-wrapper" label={t('requestInfo.size')}>
-            <Selector
-              columns={2}
-              options={CAPACITY_OPTIONS}
-              onChange={handleCapChange}
-              defaultValue={[object.size[0]]}
-            />
-          </Form.Item>
-
-          <Form.Item className="input-wrapper" label={t('requestInfo.weight')}>
-            <Radio.Group
-              name="weight"
-              value={object.weight}
-              onChange={handleInputChange}
-            >
-              <Radio value="0-5 kg">0-5 kg</Radio>
-              <Radio value="5-20 kg">5-20 kg</Radio>
-              <Radio value="+20 kg">20+ kg</Radio>
-            </Radio.Group>
-          </Form.Item>
-          <Form.Item
-            className="input-wrapper"
-            label={t('requestInfo.uploadImages')}
-          >
-            <UploadImage />
-          </Form.Item>
         </Form>
 
         {/* TODO Mischa: Reserve space for Back/Next buttons in general container
@@ -153,4 +116,4 @@ const EnterObjInfo: React.FC = () => {
   );
 };
 
-export default EnterObjInfo;
+export default EnterRequestNameDesc;

--- a/src/Pages/Sender/EnterRequestPrice.tsx
+++ b/src/Pages/Sender/EnterRequestPrice.tsx
@@ -1,22 +1,20 @@
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 import PageLayout from '../Layouts/PageLayoutTest';
 import NextButton from '../../Components/Buttons/NextButton';
 import BackButton from '../../Components/Buttons/BackButton';
 import ProgressBar from '../../Components/ProgressBar';
-import { Typography, Form, Input, Card } from 'antd';
-import { InfoCircleOutlined } from '@ant-design/icons';
+import { Form, Input } from 'antd';
 import { useDispatch, useSelector } from 'react-redux';
 import { setObjectPrice } from '../../Store/actions/requestActionCreators';
-import { IRequestInfo, ObjectInfoState } from '../../type';
+import { IRequestInfo } from '../../type';
 import { useTranslation } from 'react-i18next';
 import { logEvent } from 'firebase/analytics';
 import { analytics } from '../../firebaseConfig';
 
-const { Title } = Typography;
-const PROGRESS = 75;
-const NEXT_SCREEN = '/createSendRequest/summary';
+const PROGRESS = 80;
+const NEXT_SCREEN = '/createSendRequest/request-summary';
 
-const EnterPrice: React.FC = () => {
+const EnterRequestPrice: React.FC = () => {
   const { t } = useTranslation<string>(); // Setting the generic type to string
   const objecInfo = useSelector(
     (state: { request: IRequestInfo }) => state.request
@@ -40,9 +38,6 @@ const EnterPrice: React.FC = () => {
     });
     console.log(e.target.name);
   };
-  // Calculate screen height
-  const containerHeight = window.innerHeight * 0.9;
-  console.log(containerHeight + 'px');
 
   return (
     <PageLayout>
@@ -97,4 +92,4 @@ const EnterPrice: React.FC = () => {
   );
 };
 
-export default EnterPrice;
+export default EnterRequestPrice;

--- a/src/Pages/Sender/EnterRequestSizeWeightImage.tsx
+++ b/src/Pages/Sender/EnterRequestSizeWeightImage.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+import PageLayout from '../Layouts/PageLayoutTest';
+import NextButton from '../../Components/Buttons/NextButton';
+import BackButton from '../../Components/Buttons/BackButton';
+import ProgressBar from '../../Components/ProgressBar';
+import UploadImage from '../../Components/UploadImage';
+
+import { Form, Radio } from 'antd';
+import { useDispatch, useSelector } from 'react-redux';
+import { CAPACITY_OPTIONS } from '../../constant';
+import { setObject } from '../../Store/actions/requestActionCreators';
+import { IFirstObjectInfo, IRequestInfo } from '../../type';
+import { useTranslation } from 'react-i18next';
+import { Selector } from 'antd-mobile';
+
+import { logEvent } from 'firebase/analytics';
+import { analytics } from '../../firebaseConfig';
+
+const PROGRESS = 20;
+
+const NEXT_SCREEN = '/createSendRequest/enter_request_address';
+
+const EnterRequestSizeWeightImage: React.FC = () => {
+  const { t } = useTranslation<string>(); // Setting the generic type to string
+
+  const objecInfo = useSelector(
+    (state: { request: IRequestInfo }) => state.request
+  );
+
+  const [object, setValues] = useState<IFirstObjectInfo>({
+    name: objecInfo.name,
+    description: objecInfo.description,
+    size: objecInfo.size,
+    weight: objecInfo.weight,
+    status: objecInfo.status,
+    dealId: objecInfo.dealId,
+    contactTimestamp: objecInfo.contactTimestamp,
+  });
+
+  React.useEffect(() => {
+    dispatch(setObject(object));
+  }, [object]);
+
+  const dispatch = useDispatch();
+  const handleCapChange = (e: any) => {
+    setValues({
+      ...object,
+      size: e,
+    });
+  };
+
+  const handleInputChange = (e: any) => {
+    console.log(e);
+    setValues({
+      ...object,
+      [e.target.name]: e.target.value,
+    });
+    console.log(e.target.name);
+  };
+
+  return (
+    <PageLayout>
+      <section className="section section-form mod-nomargin-top">
+        <ProgressBar progress={PROGRESS} />
+
+        <Form
+          labelCol={{ span: 4 }}
+          wrapperCol={{ span: 14 }}
+          layout="horizontal"
+        >
+          <h2>{t('requestInfo.title')}</h2>
+
+          <Form.Item className="input-wrapper" label={t('requestInfo.size')}>
+            <Selector
+              columns={2}
+              options={CAPACITY_OPTIONS}
+              onChange={handleCapChange}
+              defaultValue={[object.size[0]]}
+            />
+          </Form.Item>
+
+          <Form.Item className="input-wrapper" label={t('requestInfo.weight')}>
+            <Radio.Group
+              name="weight"
+              value={object.weight}
+              onChange={handleInputChange}
+            >
+              <Radio value="0-5 kg">0-5 kg</Radio>
+              <Radio value="5-20 kg">5-20 kg</Radio>
+              <Radio value="+20 kg">20+ kg</Radio>
+            </Radio.Group>
+          </Form.Item>
+          <Form.Item
+            className="input-wrapper"
+            label={t('requestInfo.uploadImages')}
+          >
+            <UploadImage />
+          </Form.Item>
+        </Form>
+
+        {/* TODO Mischa: Reserve space for Back/Next buttons in general container
+          & move buttons out of div, for responsive scrolling! */}
+        <div className="form-button-container mod-display-flex mod-flex-space-between">
+          <BackButton
+            onClick={() => {
+              logEvent(analytics, 'send_1_objInfo_back_button_click');
+            }}
+          />
+          <NextButton
+            nextScreen={NEXT_SCREEN}
+            onClick={() => {
+              logEvent(analytics, 'send_1_objInfo_next_button_click');
+            }}
+          />
+        </div>
+      </section>
+    </PageLayout>
+  );
+};
+
+export default EnterRequestSizeWeightImage;

--- a/src/Pages/Sender/EnterRequestTime.tsx
+++ b/src/Pages/Sender/EnterRequestTime.tsx
@@ -1,9 +1,9 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import PageLayout from '../Layouts/PageLayoutTest';
 import NextButton from '../../Components/Buttons/NextButton';
 import BackButton from '../../Components/Buttons/BackButton';
 import ProgressBar from '../../Components/ProgressBar';
-import { Typography, Form, DatePicker } from 'antd';
+import { Form, DatePicker } from 'antd';
 import { Selector } from 'antd-mobile';
 import { useDispatch } from 'react-redux';
 import {
@@ -16,10 +16,9 @@ import { logEvent } from 'firebase/analytics';
 import { analytics } from '../../firebaseConfig';
 require('../../CSS/Calendar.css');
 
-const { Title } = Typography;
 const { RangePicker } = DatePicker;
-const PROGRESS = 50;
-const NEXT_SCREEN = '/createSendRequest/enter_price';
+const PROGRESS = 60;
+const NEXT_SCREEN = '/createSendRequest/enter_request_price';
 
 const EnterTime: React.FC = () => {
   const { t } = useTranslation<string>(); // Setting the generic type to string

--- a/src/Pages/Sender/RequestSummary.tsx
+++ b/src/Pages/Sender/RequestSummary.tsx
@@ -25,7 +25,7 @@ import { analytics } from '../../firebaseConfig';
 const PROGRESS = 100;
 const NEXT_SCREEN = '/createSendRequest';
 
-const Summary: React.FC = () => {
+const RequestSummary: React.FC = () => {
   const { t } = useTranslation<string>(); // Setting the generic type to string
   const [isModalVisible, setIsModalVisible] = useState(false);
   const dispatch = useDispatch();
@@ -37,6 +37,7 @@ const Summary: React.FC = () => {
   const objecInfo = useSelector(
     (state: { request: IRequestInfo }) => state.request
   );
+  console.log(objecInfo);
 
   const { uid } = useAuth();
 
@@ -171,4 +172,4 @@ const Summary: React.FC = () => {
   );
 };
 
-export default Summary;
+export default RequestSummary;

--- a/src/Translation/English/translation.json
+++ b/src/Translation/English/translation.json
@@ -16,12 +16,12 @@
     "delete": "Delete",
     "deleteConfirm": "Are you sure you want to delete this?"
   },
-  
+
   "timeSelector": {
     "morning": "Morning",
     "midDay": "Mid day",
     "evening": "Evening"
-    },
+  },
 
   "social": {
     "heading": "Find us on social media",
@@ -72,19 +72,18 @@
     "createButtonDescription": "Create request",
     "currentTitle": "Your current delivery requests",
     "requestList": {
-        "price": "Price",
-        "weight": "Weight",
-        "pickupAddress":"Pick-up address",
-        "deliveryAddress":"Delivery address",
-        "dateRange":"Date range",
-        "from": "From",
-        "to": "to",
-        "time": "Time",
-        "size": "Size",
-        "Images": "Images",
-        "description": "Description"
+      "price": "Price",
+      "weight": "Weight",
+      "pickupAddress": "Pick-up address",
+      "deliveryAddress": "Delivery address",
+      "dateRange": "Date range",
+      "from": "From",
+      "to": "to",
+      "time": "Time",
+      "size": "Size",
+      "Images": "Images",
+      "description": "Description"
     }
-
   },
 
   "requestInfo": {
@@ -98,6 +97,7 @@
     "uploadImages": "Upload images"
   },
   "requestAddresses": {
+    "title": "Where do you want the shipment to be picked up and sent?",
     "pickupAddress": "Pick-up address",
     "|*TBI*|pickupAddressPlaceholder": "Enter an address",
     "deliveryAddress": "Delivery address",

--- a/src/Translation/French/translation.json
+++ b/src/Translation/French/translation.json
@@ -93,6 +93,7 @@
     "uploadImages": "Importer des images"
   },
   "requestAddresses": {
+    "title": "Ou voulez-vous que l'envoi soit récupéré et envoyé?",
     "pickupAddress": "Adresse de ramassage",
     "|*TBI*|pickupAddressPlaceholder": "Entrez une adresse",
     "deliveryAddress": "Adresse de livraison",

--- a/src/Translation/German/translation.json
+++ b/src/Translation/German/translation.json
@@ -69,19 +69,18 @@
     "createButtonDescription": "Versandauftrag erstellen",
     "currentTitle": "Deine aktuellen Versandaufträge",
     "requestList": {
-        "price": "Preis",
-        "weight": "Gewicht",
-        "pickupAddress":"Abholadresse",
-        "deliveryAddress":"Lieferadresse",
-        "dateRange":"Datum",
-        "from": "Von",
-        "to": "bis",
-        "time": "Tageszeit",
-        "size": "Grösse",
-        "Images": "Bilder",
-        "description": "Beschreibung"
+      "price": "Preis",
+      "weight": "Gewicht",
+      "pickupAddress": "Abholadresse",
+      "deliveryAddress": "Lieferadresse",
+      "dateRange": "Datum",
+      "from": "Von",
+      "to": "bis",
+      "time": "Tageszeit",
+      "size": "Grösse",
+      "Images": "Bilder",
+      "description": "Beschreibung"
     }
-    
   },
 
   "requestInfo": {
@@ -95,6 +94,7 @@
     "uploadImages": "Bilder hochladen"
   },
   "requestAddresses": {
+    "title": "Wo soll die Sendung abgeholt und verschickt werden?",
     "pickupAddress": "Abholadresse",
     "|*TBI*|pickupAddressPlaceholder": "Gib eine Adresse ein",
     "deliveryAddress": "Lieferadresse",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -8,14 +8,23 @@ import MyAccount from './Pages/Profile/MyAccount';
 const About = lazy(() => import('./Pages/About'));
 const Home = lazy(() => import('./Pages/Home'));
 const Profile = lazy(() => import('./Pages/Menu'));
-const EnterObjInfo = lazy(() => import('./Pages/Sender/EnterObjInfo'));
+const EnterRequestNameDesc = lazy(
+  () => import('./Pages/Sender/EnterRequestNameDesc')
+);
+const EnterRequestSizeWeightImage = lazy(
+  () => import('./Pages/Sender/EnterRequestSizeWeightImage')
+);
 const Deliver = lazy(() => import('./Pages/Driver/Deliver'));
 const Chat = lazy(() => import('./Pages/Chat'));
 const Shipments = lazy(() => import('./Pages/Shipments'));
-const EnterAddress = lazy(() => import('./Pages/Sender/EnterAddress'));
-const EnterTime = lazy(() => import('./Pages/Sender/EnterTime'));
-const EnterPrice = lazy(() => import('./Pages/Sender/EnterPrice'));
-const SummaryRequest = lazy(() => import('./Pages/Sender/Summary'));
+const EnterRequestAddress = lazy(
+  () => import('./Pages/Sender/EnterRequestAddress')
+);
+const EnterRequestTime = lazy(() => import('./Pages/Sender/EnterRequestTime'));
+const EnterRequestPrice = lazy(
+  () => import('./Pages/Sender/EnterRequestPrice')
+);
+const RequestSummary = lazy(() => import('./Pages/Sender/RequestSummary'));
 const UserRequests = lazy(() => import('./Pages/UserRequestsScreen'));
 const AdminDashboard = lazy(() => import('./Pages/Admin/AdminDashboard'));
 const AllRequests = lazy(() => import('./Pages/Admin/AllRequests'));
@@ -78,11 +87,18 @@ export const routes: Array<Route> = [
     component: CreateSendRequest,
   },
   {
-    key: 'enterObjInfo-route',
-    title: 'EnterObjInfo',
-    path: '/createSendRequest/enterObjInfo',
+    key: 'EnterRequestNameDesc-route',
+    title: 'EnterRequestNameDesc',
+    path: '/createSendRequest/enter_request_name_desc',
     enabled: true,
-    component: EnterObjInfo,
+    component: EnterRequestNameDesc,
+  },
+  {
+    key: 'EnterRequestSizeWeightImage-route',
+    title: 'EnterRequestSizeWeightImage',
+    path: '/createSendRequest/enter_request_size_weight_image',
+    enabled: true,
+    component: EnterRequestSizeWeightImage,
   },
   {
     key: 'deliver-route',
@@ -106,32 +122,32 @@ export const routes: Array<Route> = [
     component: Shipments,
   },
   {
-    key: 'enterAddress-route',
-    title: 'EnterAddress',
-    path: '/createSendRequest/enter_address',
+    key: 'enterRequestAddress-route',
+    title: 'EnterRequestAddress',
+    path: '/createSendRequest/enter_request_address',
     enabled: true,
-    component: EnterAddress,
+    component: EnterRequestAddress,
   },
   {
-    key: 'enterTime-route',
-    title: 'EnterTime',
-    path: '/createSendRequest/enter_time',
+    key: 'enterRequestTime-route',
+    title: 'EnterRequestTime',
+    path: '/createSendRequest/enter_request_time',
     enabled: true,
-    component: EnterTime,
+    component: EnterRequestTime,
   },
   {
-    key: 'enterPrice-route',
-    title: 'EnterPrice',
-    path: '/createSendRequest/enter_price',
+    key: 'enterRequestPrice-route',
+    title: 'EnterRequestPrice',
+    path: '/createSendRequest/enter_request_price',
     enabled: true,
-    component: EnterPrice,
+    component: EnterRequestPrice,
   },
   {
     key: 'summary-request',
     title: 'SummaryRequest',
-    path: '/createSendRequest/summary',
+    path: '/createSendRequest/request-summary',
     enabled: true,
-    component: SummaryRequest,
+    component: RequestSummary,
   },
   {
     key: 'user-requests',


### PR DESCRIPTION
Changed screen names in sender flow to match route ones
Create a new screen to split enterObjInfo in 2
Added title to enterRequestAddresses with translation
Some cleaning 

Known limitations:
-  Same title for both screen