### PR TITLE
Adding meta pixel to allow for FB/IG advertising

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,6 +39,23 @@
     <!-- Add Cookiescript consent manager -->
     <script type="text/javascript" charset="UTF-8" src="//cdn.cookie-script.com/s/352d41aa6940aa9f18ef013ba45a515d.js"></script>
     
+    <!-- Add Meta Pixel -->
+  <script>
+    !function(f,b,e,v,n,t,s)
+    {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+    if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+    n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];
+    s.parentNode.insertBefore(t,s)}(window, document,'script',
+    'https://connect.facebook.net/en_US/fbevents.js');
+    fbq('init', '323476876969281');
+    fbq('track', 'PageView');
+  </script>
+  <noscript><img height="1" width="1" style="display:none"
+    src="https://www.facebook.com/tr?id=323476876969281&ev=PageView&noscript=1"
+  /></noscript>
+  
     <title>Portato</title>
   </head>
   <body>


### PR DESCRIPTION
This pull request introduces the integration of the Facebook Meta Pixel by adding the required script snippet to the <head> section of the main HTML file. This will allow to track user interactions on our web app, facilitating more accurate and targeted advertising on Facebook and Instagram.